### PR TITLE
feat(backend): http 요청 관련 유틸 함수에서 전역 `Semaphore` 사용

### DIFF
--- a/backend/utils/semaphore.py
+++ b/backend/utils/semaphore.py
@@ -1,0 +1,50 @@
+from asyncio import Semaphore
+from contextlib import asynccontextmanager
+from typing import Optional
+from aiohttp.web import HTTPClientError, HTTPServerError
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class _HTTPSemaphore:
+    _instance = None
+
+    def __new__(cls, *args, **kwargs):
+        if cls._instance is None:
+            print("New ONNXRuntime instance has been created")
+            cls._instance = super().__new__(cls)
+
+        return cls._instance
+
+    def __init__(self, limit: int = 2):
+        self.limit = 2
+        self._semaphore = Semaphore(limit)
+
+    @property
+    def semaphore(self):
+        return self._semaphore
+
+    @classmethod
+    def get_instance(cls):
+        if cls._instance is None:
+            raise Exception("생성자를 먼저 호출하세요.")
+        assert cls._instance is not None
+        return cls._instance
+
+
+@asynccontextmanager
+async def http_semaphore(semaphore: Optional[Semaphore] = None, limit: int = 2):
+    if semaphore is None:
+        http_semaphore = _HTTPSemaphore(limit)
+        semaphore = http_semaphore.semaphore
+
+    try:
+        async with semaphore:
+            yield
+    except HTTPClientError as e:
+        logger.exception(f"잘못된 HTTP 요청입니다. ({e})")
+    except HTTPServerError as e:
+        logger.exception(f"HTTP 서버에서 오류가 발생했습니다. ({e})")
+    except Exception as e:
+        logger.exception(f"HTTP 요청 처리 중 오류가 발생했습니다. ({e})")


### PR DESCRIPTION
<!--
Title: <type>([optional scope]): <description>

## Type

- build - Changes that affect the build system or external dependencies (dependencies update)
- docs - Documentation only changes
- feat - A new feature
- fix - A bug fix
- chore - Changes which does not touch the code
- refactor - A code change that contains refactor
- style - Changes that do not affect the meaning of the code
- test - Adding missing tests or correcting existing tests and also changes for our test app
- perf - A code change that improves performance

See details: https://flank.github.io/flank/pr_titles/
-->

## Details
- `_HTTPSemaphore`: `asyncio.Semaphore` 인스턴스 포함하는 싱글톤 클래스
- `http_semaphore`
    - `async with` 대신 어노테이션으로 semaphore 사용
    - `aiohttp` 관련 공통 에러 핸들링
## Usage
```python
# backend/utils/embed.py
...
@http_semaphore()
async def aembed_onnx(
    texts: str | List[str],
    session: ClientSession,
    chunking: bool = True,
    truncate: bool = True,
) -> EmbedResponse:
    body = {"inputs": texts, "chunking": chunking, "truncate": truncate}
    async with session.post(f"{embed_url}/embed", json=body) as res:
        if res.status == 200:
            data = await res.json()
            return data

        raise Exception("텍스트 임베딩에 실패했습니다.")
...
```
